### PR TITLE
Multiple Entries with the same filename fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,9 +24,7 @@ var renderer = function(data, options, callback) {
     if (_.isString(entry)) entry = [entry];
     if (_.isArray(entry)) {
       entry = entry.map(function(x){ return path.join(cwd, x); });
-      return _.zipObject(entry.map(function(x){
-        return path.basename(x, path.extname(x));
-      }), entry);
+      return _.zipObject(entry, entry);
     }
     return _.mapValues(entry, function(x){ return path.join(cwd, x); });
   })(userConfig.entry);


### PR DESCRIPTION
There currently exists a bug where given a config where are all the file names are the same, it outputted config will only contain a single file name. See example below:

YAML Config:
```
webpack:
  entry:
    - templates/example/js/app.js
    - templates/lp_blue_01282019/js/app.js
    - templates/lp_yellow_01152019/js/app.js
    - templates/lp_pink_01142019/js/app.js
```
Outputted Webpack Config:
```
{
    "app" : "templates/lp_pink_01142019/js/app.js"
}
```

The fix included in the pull request changes this behavior so that the object key is the entire path of the file which ensures there won't be any overwriting.

So with the following YAML config:
```
webpack:
  entry:
    - templates/example/js/app.js
    - templates/lp_blue_01282019/js/app.js
    - templates/lp_yellow_01152019/js/app.js
    - templates/lp_pink_01142019/js/app.js
```
You will get this Webpack Config:
```
{
  "templates/example/js/app.js" : "templates/example/js/app.js",
  "templates/lp_blue_01282019/js/app.js" : "templates/lp_blue_01282019/js/app.js",
  "templates/lp_yellow_01152019/js/app.js" : "templates/lp_yellow_01152019/js/app.js",
  "templates/lp_pink_01142019/js/app.js" : "templates/lp_pink_01142019/js/app.js"
}
```

Note, in the above example shown I have removed the absolute path so it's easier to read and follow.